### PR TITLE
Use the correct hive partition type information (hacky solution)

### DIFF
--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -52,6 +52,7 @@ _SQL_TO_PYTHON_SCALARS = {
     "FLOAT": np.float32,
     "DECIMAL": np.float32,
     "BIGINT": np.int64,
+    "INT": np.int32,  # Although not in the standard, makes compatibility easier
     "INTEGER": np.int32,
     "SMALLINT": np.int16,
     "TINYINT": np.int8,
@@ -156,6 +157,14 @@ def sql_to_python_value(sql_type: str, literal_value: Any) -> Any:
         if str(literal_value) == "None":
             # NULL time
             return pd.NaT  # pragma: no cover
+
+        if isinstance(literal_value, str):
+            if sql_type == "DATE":
+                return datetime.strptime(literal_value, "%Y-%m-%d")
+            elif sql_type.startswith("TIME("):
+                return datetime.strptime(literal_value, "%H:%M:%S %Y")
+            elif sql_type.startswith("TIMESTAMP("):
+                return datetime.strptime(literal_value)
 
         tz = literal_value.getTimeZone().getID()
         assert str(tz) == "UTC", "The code can currently only handle UTC timezones"


### PR DESCRIPTION
Hi @gallamine !

Thanks for your very good bug fix in https://github.com/nils-braun/dask-sql/pull/180!
I tried to add to your PR also a very hacky solution for https://github.com/nils-braun/dask-sql/issues/181.

In my small tests, that has worked, but I think it will break on many occasions. I am wondering if we should go down this path and make it more robust, or if we should invest in a better solution where we do not need to translate between the string representation of the values from `DESCRIBE FORMATTED` an the python types all the time. I took this idea from the blazing folks, but I am open to other ideas.

What do you think?